### PR TITLE
fix minor mistake without impact

### DIFF
--- a/examples/sorting/sorting_032.py
+++ b/examples/sorting/sorting_032.py
@@ -560,7 +560,7 @@ def got() -> operations.GraphOfOperations:
     """
     operations_graph = operations.GraphOfOperations()
 
-    plans = operations.Generate(2, 1)
+    plans = operations.Generate(1, 1)
     operations_graph.append_operation(plans)  # generate the sublists
     for i in range(1, 3):
         list_id = f"List {i}"


### PR DESCRIPTION
fix mistake in sorting example for 32 elements, which has no impact, since the respective parameter is not used in the implementation of the generation prompt

reported in issue #35 